### PR TITLE
moved scripts, amended setup.py for generating built distributions

### DIFF
--- a/keynoteapi/check_keynote.py
+++ b/keynoteapi/check_keynote.py
@@ -7,7 +7,8 @@ import time
 import logging
 import argparse
 import nagiosplugin
-from keynoteapi import keynoteapi, keynotecli
+import keynoteapi
+import keynotecli
 
 _log = logging.getLogger('nagiosplugin')
 

--- a/keynoteapi/keynoteCli.py
+++ b/keynoteapi/keynoteCli.py
@@ -6,7 +6,7 @@
 """
 
 import argparse
-from keynoteapi import keynotecli
+import keynotecli
 
 
 def main():

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,11 @@ def read(*filenames, **kwargs):
 setup(
     name='keynoteapi',
     packages=find_packages(exclude=['tests']),
+    entry_points={'console_scripts': [
+        'check_keynote = keynoteapi.check_keynote:main',
+        'keynoteCli = keynoteapi.keynoteCli:main'
+        ]
+    },
     description='Access the Keynote Systems API (api.keynote.com)',
     long_description=read('README.md'),
     version=PKG_VER,


### PR DESCRIPTION
- Changes allow generating built distributions (tested for RPM) (e.g., for systems provisioned without _pip_).
- `python setup.py bdist --format=rpm`
- RPM package installs `check_keynote` and `keynoteCli` under _/usr/bin_
```
rpm -qlp dist/keynoteapi-0.1.0-1.noarch.rpm 
/usr/bin/check_keynote
/usr/bin/keynoteCli
/usr/lib/python2.6/site-packages/keynoteapi-0.1.0-py2.6.egg-info
/usr/lib/python2.6/site-packages/keynoteapi-0.1.0-py2.6.egg-info/PKG-INFO
/usr/lib/python2.6/site-packages/keynoteapi-0.1.0-py2.6.egg-info/SOURCES.txt
/usr/lib/python2.6/site-packages/keynoteapi-0.1.0-py2.6.egg-info/dependency_links.txt
/usr/lib/python2.6/site-packages/keynoteapi-0.1.0-py2.6.egg-info/entry_points.txt
/usr/lib/python2.6/site-packages/keynoteapi-0.1.0-py2.6.egg-info/top_level.txt
/usr/lib/python2.6/site-packages/keynoteapi/__init__.py
/usr/lib/python2.6/site-packages/keynoteapi/__init__.pyc
/usr/lib/python2.6/site-packages/keynoteapi/__init__.pyo
/usr/lib/python2.6/site-packages/keynoteapi/check_keynote.py
/usr/lib/python2.6/site-packages/keynoteapi/check_keynote.pyc
/usr/lib/python2.6/site-packages/keynoteapi/check_keynote.pyo
/usr/lib/python2.6/site-packages/keynoteapi/keynoteCli.py
/usr/lib/python2.6/site-packages/keynoteapi/keynoteCli.pyc
/usr/lib/python2.6/site-packages/keynoteapi/keynoteCli.pyo
/usr/lib/python2.6/site-packages/keynoteapi/keynoteapi.py
/usr/lib/python2.6/site-packages/keynoteapi/keynoteapi.pyc
/usr/lib/python2.6/site-packages/keynoteapi/keynoteapi.pyo
/usr/lib/python2.6/site-packages/keynoteapi/keynotecli.py
/usr/lib/python2.6/site-packages/keynoteapi/keynotecli.pyc
/usr/lib/python2.6/site-packages/keynoteapi/keynotecli.pyo
```